### PR TITLE
Change default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The process executes rsync from Git working tree to SubVersion working tree with
 
 ### default behavior
 
-rsync will read [default .rsync-filter file](https://github.com/yukihiko-shinoda/dockerfile-deploy-wordpress-plugin/blob/master/runner/project/roles/deploy-wordpress-plugin/templates/.rsync-filter.j2).
+rsync will read [default .rsync-filter file](https://github.com/yukihiko-shinoda/dockerfile-deploy-wordpress-plugin/blob/main/runner/project/roles/deploy-wordpress-plugin/templates/.rsync-filter.j2).
 
 ### customizing behavior
 


### PR DESCRIPTION
This pull request updates branch references from "master" to "main" to align with modern naming conventions and updates documentation links accordingly.

Branch and workflow updates:

* Updated the GitHub Actions workflow in `.github/workflows/test.yml` to trigger on pushes and pull requests to the `main` branch instead of `master`.

Documentation updates:

* Updated the `README.md` to reference the `.rsync-filter` file in the `main` branch instead of `master`.